### PR TITLE
new name for contextQuery, and changes to contextQuery properties

### DIFF
--- a/src/main/java/org/neo4j/server/rest/repr/TNRSResultsRepresentation.java
+++ b/src/main/java/org/neo4j/server/rest/repr/TNRSResultsRepresentation.java
@@ -53,7 +53,7 @@ public class TNRSResultsRepresentation extends MappingRepresentation {
 			protected void serialize(final MappingSerializer serializer) {
 
 				serializer.putString("context_name", result.context.getDescription().name);
-				serializer.putNumber("content_rootnode_ott_id", (Long) result.context.getRootNode().getProperty(
+				serializer.putNumber("context_rootnode_ott_id", (Long) result.context.getRootNode().getProperty(
 						OTVocabularyPredicate.OT_OTT_ID.propertyName()));
 				serializer.putList("ambiguous_names", OTRepresentationConverter
 						.getListRepresentation(result.namesNotMatched));
@@ -151,13 +151,15 @@ public class TNRSResultsRepresentation extends MappingRepresentation {
 				Node matchedNode = match.getMatchedNode();
 
 				// add these properties for all taxa
-				serializer.putBoolean("is_perfect_match", match.getIsPerfectMatch());
+//				serializer.putBoolean("is_perfect_match", match.getIsPerfectMatch());
 				serializer.putBoolean("is_approximate_match", match.getIsApproximate());
 				serializer.putNumber("matched_node_id", matchedNode.getId());
-				serializer.putString("matched_name", (String) matchedNode.getProperty(
-						OTVocabularyPredicate.OT_OTT_TAXON_NAME.propertyName()));
-				serializer.putNumber("matched_ott_id", (Long) matchedNode.getProperty(OTVocabularyPredicate.OT_OTT_ID
-						.propertyName()));
+//				serializer.putString("matched_name", (String) matchedNode.getProperty(OTVocabularyPredicate.OT_OTT_TAXON_NAME.propertyName()));
+//				serializer.putNumber("matched_ott_id", (Long) matchedNode.getProperty(OTVocabularyPredicate.OT_OTT_ID.propertyName()));
+				serializer.putString(OTVocabularyPredicate.OT_OTT_TAXON_NAME.propertyName(),
+						(String) matchedNode.getProperty(OTVocabularyPredicate.OT_OTT_TAXON_NAME.propertyName()));
+				serializer.putNumber(OTVocabularyPredicate.OT_OTT_ID.propertyName(),
+						(Long) matchedNode.getProperty(OTVocabularyPredicate.OT_OTT_ID.propertyName()));
 				serializer.putString("search_string", match.getSearchString());
 				serializer.putNumber("score", match.getScore());
 

--- a/src/main/java/org/opentree/taxonomy/plugins/TNRS.java
+++ b/src/main/java/org/opentree/taxonomy/plugins/TNRS.java
@@ -181,10 +181,55 @@ public class TNRS extends ServerPlugin {
 			return 0;
 		}
 	}
-    
-    @Description("Return information on potential matches to a search query")
+
+    @Description("DEPRECATED. This service is an alias for the service simply named `contextQuery` and is kept only for backwards compatibility. Use `contextQuery` instead."
+    		+ "This one will be removed from a future version of the OpenTree API.")
     @PluginTarget(GraphDatabaseService.class)
     public Representation contextQueryForNames(
+            @Source GraphDatabaseService graphDb,
+
+            /*
+            @Description("A comma-delimited string of taxon names to be queried against the taxonomy db. This is an alternative to the use of the 'names' parameter")
+            	@Parameter(name = "queryString", optional = true) String queryString,
+            @Description("The name of the taxonomic context to be searched")
+            	@Parameter(name = "contextName", optional = true) String contextName,
+        	@Description("An array of taxon names to be queried. This is an alternative to the use of the 'queryString' parameter")
+        		@Parameter(name="names", optional = true) String[] names,
+        	@Description("An array of ids to use for identifying names. These will be set in the id field of each name result. If this parameter is used, ids will be treated as strings.")
+    			@Parameter(name="idStrings", optional = true) String[] idStrings,
+        	@Description("An array of ids to use for identifying names. These will be set in the id field of each name result. If this parameter is used, ids will be treated as ints.")
+    			@Parameter(name="idInts", optional = true) Long[] idInts,
+        	@Description("A boolean indicating whether or not to include deprecated taxa in the search.")
+    			@Parameter(name="includeDeprecated", optional = true) Boolean includeDeprecated,
+    		@Description("A boolean indicating whether or not to perform approximate string (a.k.a. \"fuzzy\") matching. Will greatly improve speed if this is turned OFF (false). By default, however, it is on (true).")
+            	@Parameter(name="doApproximateMatching", optional = true) Boolean doFuzzyMatching,
+    		@Description("Whether to include so-called 'dubious' taxa--those which are not accepted by OTT.")
+            	@Parameter(name="includeDubious", optional=true) Boolean includeDubious) throws ContextNotFoundException {
+            	*/
+
+            @Description("No information is provided for this service. Use service `contextQuery` instead.")
+	        	@Parameter(name = "queryString", optional = true) String queryString,
+	        @Description("No information is provided for this service. Use service `contextQuery` instead.")
+	        	@Parameter(name = "contextName", optional = true) String contextName,
+	    	@Description("No information is provided for this service. Use service `contextQuery` instead.")
+	    		@Parameter(name="names", optional = true) String[] names,
+	        @Description("No information is provided for this service. Use service `contextQuery` instead.")
+            	@Parameter(name="idStrings", optional = true) String[] idStrings,
+            @Description("No information is provided for this service. Use service `contextQuery` instead.")
+            	@Parameter(name="idInts", optional = true) Long[] idInts,
+            @Description("No information is provided for this service. Use service `contextQuery` instead.")
+            	@Parameter(name="includeDeprecated", optional = true) Boolean includeDeprecated,
+            @Description("No information is provided for this service. Use service `contextQuery` instead.")
+            	@Parameter(name="doApproximateMatching", optional = true) Boolean doFuzzyMatching,
+            @Description("No information is provided for this service. Use service `contextQuery` instead.")
+            	@Parameter(name="includeDubious", optional=true) Boolean includeDubious) throws ContextNotFoundException {
+
+    	return contextQuery(graphDb, queryString, contextName, names, idStrings, idInts, includeDeprecated, doFuzzyMatching, includeDubious);
+    }
+    
+    @Description("Return information about potential matches to a set of taxonomic names. This service uses taxonomic contexts to narrow search parameters and help disambiguate synonyms and homonyms. ")
+    @PluginTarget(GraphDatabaseService.class)
+    public Representation contextQuery(
             @Source GraphDatabaseService graphDb,
 
             @Description("A comma-delimited string of taxon names to be queried against the taxonomy db. This is an alternative to the use of the 'names' parameter")


### PR DESCRIPTION
@jimallman,

I have a couple of (hopefully painless) requests for you. In this commit are a couple of consistency improvements for TNRS, which I would like to have propagated to devapi (at least) before the hackathon. Since we're working on this now, it seemed like as good a time as any.
1. I am deprecating the name `contextQueryForNames` in favor of just `contextQuery`. The service will be identical, and will still be available under the old name, so nothing will break. But if you would please update your references to use the new name, that would be great!
2. On a related note, I also deprecated `autocompleteBoxQuery` in favor of just `autocompleteQuery` a while ago, which should also be changed in various applications if it hasn't already.
3. The results of the contextQuery need some tweaking (as we have discussed elsewhere). There will be some changes that won't affect anything now (but which will be useful later). However, I am also switching the two arguably most important existing properties over to their ot:X designations for consistency with other OT applications. They are:

matched_name -> ot:ottTaxonName
matched_ott_id -> ot:ottId

These property changes will need to be matched by changes in clients or OTU mapping (and other uses of contextQuery, if they exist) will fail.

All the changes are in this pull request. Could you please make the required adjustments to the curator (and any other client apps under your control?) and then merge this into master so these will be reflected on devapi?
