### PR TITLE
Update testing

### DIFF
--- a/ws-tests/opentreetesting.py
+++ b/ws-tests/opentreetesting.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+from ConfigParser import SafeConfigParser
+from cStringIO import StringIO
+import requests
+import gzip
+import json
+import sys
+import os
+
+_CONFIG = None
+_CONFIG_FN = None
+if 'VERBOSE_TESTING' in os.environ:
+    try:
+        _VERBOSITY_LEVEL = int(os.environ['VERBOSE_TESTING'])
+    except:
+        _VERBOSITY_LEVEL = 1
+else:
+    _VERBOSITY_LEVEL = 0
+def debug(s):
+    if _VERBOSITY_LEVEL > 0:
+        sys.stderr.write('testing-harness: {s}\n'.format(s=s))
+
+def config(section=None, param=None, default=None):
+    '''
+    Returns the config object if `section` and `param` are None, or the 
+        value for the requested parameter.
+    
+    If the parameter (or the section) is missing, the exception is logged and
+        None is returned.
+    '''
+    global _CONFIG, _CONFIG_FN
+    if _CONFIG is None:
+        _CONFIG_FN = os.path.abspath('test.conf')
+        _CONFIG = SafeConfigParser()
+        _CONFIG.read(_CONFIG_FN)
+        parse_argv_as_options(_CONFIG)
+    if section is None and param is None:
+        return _CONFIG
+    try:
+        v = _CONFIG.get(section, param)
+        return v
+    except:
+        if default != None:
+            return default
+        else:
+            sys.stderr.write('Config file "%s" does not contain option "%s" in section "%s"\n' % (_CONFIG_FN, param, section))
+            return None
+
+# Obtain command line option assignments given in the form section:parameter=option
+
+def parse_argv_as_options(_CONFIG):
+    for arg in sys.argv[1:]:
+        equatands = arg.split('=')
+        if len(equatands) == 2:
+            sec_param = equatands[0].split(':')
+            if len(sec_param) == 2:
+                if not _CONFIG.has_section(sec_param[0]):
+                    _CONFIG.add_section(sec_param[0])
+                _CONFIG.set(sec_param[0], sec_param[1], equatands[1])
+            else:
+                sys.stderr.write('Command line argument %s not in form section:parameter=value' % (arg))
+        else:
+            sys.stderr.write('Command line argument %s not in form section:parameter=value' % (arg))
+
+def summarize_json_response(resp):
+    sys.stderr.write('Sent request to %s\n' %(resp.url))
+    raise_for_status(resp)
+    try:
+        results = resp.json()
+    except:
+        print 'Non json resp is:', resp.text
+        return False
+    if isinstance(results, unicode) or isinstance(results, str):
+        print results
+        er = json.loads(results)
+        print er
+        print json.dumps(er, sort_keys=True, indent=4)
+        sys.stderr.write('Getting JavaScript string. Object expected.\n')
+        return False
+    print json.dumps(results, sort_keys=True, indent=4)
+    return True
+
+def summarize_gzipped_json_response(resp):
+    sys.stderr.write('Sent request to %s\n' %(resp.url))
+    raise_for_status(resp)
+    try:
+        uncompressed = gzip.GzipFile(mode='rb', fileobj=StringIO(resp.content)).read()
+        results = uncompressed
+    except:
+        raise 
+    if isinstance(results, unicode) or isinstance(results, str):
+        er = json.loads(results)
+        print json.dumps(er, sort_keys=True, indent=4)
+        return True
+    else:
+        print 'Non gzipped response, but not a string is:', results
+        return False
+
+def get_obj_from_http(url,
+                     verb='GET',
+                     data=None,
+                     headers=None):
+    '''Call `url` with the http method of `verb`. 
+    If specified `data` is passed using json.dumps
+    returns the json content of the web service or raise an HTTP error
+    '''
+    if headers is None:
+        headers = {
+            'content-type' : 'application/json',
+            'accept' : 'application/json',
+        }
+    if data:
+        resp = requests.request(verb,
+                                translate(url),
+                                headers=headers,
+                                data=json.dumps(data),
+                                allow_redirects=True)
+    else:
+        resp = requests.request(verb,
+                                translate(url),
+                                headers=headers,
+                                allow_redirects=True)
+    debug('Sent {v} to {s}\n'.format(v=verb, s=resp.url))
+    debug('Got status code {c}\n'.format(c=resp.status_code))
+    if resp.status_code != 200:
+        debug('Full response: {r}\n'.format(r=resp.text))
+        raise_for_status(resp)
+    return resp.json()
+
+def test_http_json_method(url,
+                     verb='POST',
+                     data=None,
+                     headers=None,
+                     expected_status=200,
+                     expected_response=None, 
+                     return_bool_data=False,
+                     is_json=True):
+    '''Call `url` with the http method of `verb`. 
+    If specified `data` is passed using json.dumps
+    returns True if the response:
+         has the expected status code, AND
+         has the expected content (if expected_response is not None)
+    '''
+    fail_return = (False, None) if return_bool_data else False
+    if headers is None:
+        headers = {
+            'content-type' : 'application/json',
+            'accept' : 'application/json',
+        }
+    if data:
+        resp = requests.request(verb,
+                                translate(url),
+                                headers=headers,
+                                data=json.dumps(data),
+                                allow_redirects=True)
+    else:
+        resp = requests.request(verb,
+                                translate(url),
+                                headers=headers,
+                                allow_redirects=True)
+        debug('Sent {v} to {s}\n'.format(v=verb, s=resp.url))
+    debug('Got status code {c} (expecting {e})\n'.format(c=resp.status_code,e=expected_status))
+    if resp.status_code != expected_status:
+        debug('Did not get expect response status. Got:\n{s}'.format(s=resp.status_code))
+        debug('Full response: {r}\n'.format(r=resp.text))
+        raise_for_status(resp)
+        # this is required for the case when we expect a 4xx/5xx but a successful return code is returned
+        return fail_return
+    if expected_response is not None:
+        if not is_json:
+             return (True, resp.text, True) if return_bool_data else True
+        try:
+            results = resp.json()
+            if results != expected_response:
+                debug('Did not get expect response content. Got:\n{s}'.format(s=resp.text))
+                return fail_return
+        except:
+            debug('Non json resp is:' + resp.text)
+            return fail_return
+        if _VERBOSITY_LEVEL > 1:
+            debug(unicode(results))
+    elif _VERBOSITY_LEVEL > 1:
+        debug('Full response: {r}\n'.format(r=resp.text))
+    if not is_json:
+             return (True, resp.text, True) if return_bool_data else True
+    return (True, resp.json(), True) if return_bool_data else True
+
+def raise_for_status(resp):
+    try:
+        resp.raise_for_status()
+    except Exception, e:
+        try:
+            j = resp.json()
+            m = '\n    '.join(['"{k}": {v}'.format(k=k, v=v) for k, v in r.items()])
+            sys.stderr.write('resp.json = {t}'.format(t=m))
+        except:
+            if resp.text:
+                sys.stderr.write('resp.text = {t}\n'.format(t=resp.text))
+        raise e
+
+
+
+def api_is_readonly():
+    return config('host', 'allowwrite', 'true') == 'false'
+
+def exit_if_api_is_readonly(fn):
+    if not api_is_readonly():
+        return
+    if _VERBOSITY_LEVEL > 0:
+        debug('Running in read-only mode. Skipped {}'.format(fn))
+    else:
+        sys.stderr.write('s')
+    sys.exit(0)
+
+
+# Mimic the behavior of apache so that services can be tested without
+# having apache running.  See opentree/deploy/setup/opentree-shared.conf
+
+translations = [('/v2/study/', '/phylesystem/v1/study/'),
+                ('/cached/', '/phylesystem/default/cached/'),
+                # treemachine
+                ('/v2/tree_of_life/', '/db/data/ext/tree_of_life/graphdb/'),
+                ('/v2/graph/', '/db/data/ext/graph/graphdb/'),
+                # taxomachine
+                ('/v2/tnrs/', '/db/data/ext/tnrs_v2/graphdb/'),
+                ('/v2/taxonomy/', '/db/data/ext/taxonomy/graphdb/'),
+                # oti
+                ('/v2/studies/', '/db/data/ext/studies/graphdb/'),
+]
+
+def translate(s):
+    if config('host', 'translate', 'false') == 'true':
+        for (src, dst) in translations:
+            if s.startswith(src):
+                return dst + s[len(src):]
+    return s

--- a/ws-tests/test_taxonomy_about.py
+++ b/ws-tests/test_taxonomy_about.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+import sys, os
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/taxonomy/about'
+test, result, _ = test_http_json_method(SUBMIT_URI,
+                                        expected_status=200,
+                                        return_bool_data=True)
+if not test:
+    sys.exit(1)
+if u'source' not in result:
+    sys.stderr.write('No source reported in \n{}'.format(result))
+    sys.exit(1)
+if u'author' not in result:
+    sys.stderr.write('No author reported in \n{}'.format(result))
+    sys.exit(1)
+if u'weburl' not in result:
+    sys.stderr.write('No weburl reported in \n{}'.format(result))
+    sys.exit(1)

--- a/ws-tests/test_taxonomy_deprecated_taxa.py
+++ b/ws-tests/test_taxonomy_deprecated_taxa.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+import sys, os
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/taxonomy/deprecated_taxa'
+# currently returns an empty list
+test, result, _ = test_http_json_method(SUBMIT_URI,
+                                        expected_status=200,
+                                        expected_response=[],
+                                        return_bool_data=True)
+if not test:
+    sys.exit(1)
+

--- a/ws-tests/test_taxonomy_flags.py
+++ b/ws-tests/test_taxonomy_flags.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+import sys, os
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/taxonomy/flags'
+test, result, _ = test_http_json_method(SUBMIT_URI,
+                                        expected_status=200,
+                                        return_bool_data=True)
+if not test:
+    sys.exit(1)
+# result is large dictionary.  Will do a minimal test
+if u'incertae_sedis' not in result:
+    sys.stderr.write('No reported count of incertae_sedis taxa')
+    sys.exit(1)
+if u'unclassified' not in result:
+    sys.stderr.write('No reported count of unclassified taxa')
+    sys.exit(1)

--- a/ws-tests/test_taxonomy_lica.py
+++ b/ws-tests/test_taxonomy_lica.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import sys, os
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/taxonomy/lica'
+test, result, _ = test_http_json_method(SUBMIT_URI,
+                                        data={"ott_ids":[515698,590452,409712,643717]},
+                                        expected_status=200,
+                                        return_bool_data=True)
+if not test:
+    sys.exit(1)
+if u'lica' not in result:
+    sys.stderr.write('No lica found in \n{}'.format(result))
+    sys.exit(1)
+lica = result[u'lica']
+if u'ot:ottId' not in lica:
+    sys.stderr.write('No ott id returned in lica \n{}'.format(result))
+    sys.exit(1)
+expectedId = 1042120
+if lica[u'ot:ottId'] != expectedId:
+    sys.stderr.write('Expected , found {}'.format(lica[u'ottId']))
+    sys.exit(1)
+

--- a/ws-tests/test_taxonomy_lica2.py
+++ b/ws-tests/test_taxonomy_lica2.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import sys, os
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/taxonomy/lica'
+test, result, _ = test_http_json_method(SUBMIT_URI,
+                                        data={"ott_ids":[901642, 55033]},
+                                        expected_status=200,
+                                        return_bool_data=True)
+if not test:
+    sys.exit(1)
+if u'lica' not in result:
+    sys.stderr.write('No lica found in returned: \n{}'.format(result))
+    sys.exit(1)
+lica = result[u'lica']
+if u'ot:ottId' not in lica:
+    sys.stderr.write('No ottId found in returned: \n{}'.format(result))
+    sys.exit(1)
+expectedId = 637370
+if lica[u'ot:ottId'] != expectedId:
+    errstr = 'Expected {} , found {}'
+    sys.stderr.write(errstr.format(expectedId,lica[u'ot:ottId']))
+    sys.exit(1)
+

--- a/ws-tests/test_taxonomy_lica_bad_taxon.py
+++ b/ws-tests/test_taxonomy_lica_bad_taxon.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+import sys, os
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/taxonomy/lica'
+test, result, _ = test_http_json_method(SUBMIT_URI,
+                                        data={"ott_ids":[5551856,821970,770319]},
+                                        expected_status=200,
+                                        return_bool_data=True)
+if not test:
+    sys.exit(1)
+if u'lica' not in result:
+    sys.stderr.write('No lica found in result {}'.format(result))
+    sys.exit(1)
+lica = result[u'lica']
+if u'ot:ottId' not in lica:
+    sys.stderr.write('No ottId found in result {}'.format(result))
+    sys.exit(1)
+expectedId = 770319
+if lica[u'ot:ottId'] != expectedId:
+    sys.stderr.write('Expected {}, found {}'.format(expectedId,lica[u'ottId']))
+    sys.exit(1)
+if u'ott_ids_not_found' not in result:
+    errstr = "Expected to find list of ott_ids_not_found, but didn't in {}"
+    sys.stderr.write(errstr,result)
+    sys.exit(1)
+badids = result[u'ott_ids_not_found']
+expectedBadId = 5551856
+if expectedBadId not in badids:
+    errstr = 'Expected to find {} in bad ids, found {}'
+    sys.stderr.write(errstr.format(expectedBadId,badids))
+    sys.exit(1)
+
+

--- a/ws-tests/test_taxonomy_subtree.py
+++ b/ws-tests/test_taxonomy_subtree.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+import sys, os, re
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/taxonomy/subtree'
+test, result, _ = test_http_json_method(SUBMIT_URI,
+                                        data={"ott_id":515698},
+                                        expected_status=200,
+                                        return_bool_data=True)
+if not test:
+    sys.exit(1)
+tree = result[u'subtree']
+if tree is None or tree == '':
+    sys.stderr.write("Expected result to have a tree, but found {}".format(result))
+    sys.exit(1)
+# trying to avoid dealing with a newick parser here...
+ROOTTAXONSTR = "\)Barnadesia_ott515698;"
+namecheck =  re.compile(ROOTTAXONSTR)
+if re.search(namecheck,tree) is None:
+    errstr = "requested taxon {} does not appear at root of tree:\n {}"
+    sys.stderr.write(errstr,ROOTTAXONSTR[1:],tree)
+    sys.exit(1)

--- a/ws-tests/test_taxonomy_subtree_descendant_species.py
+++ b/ws-tests/test_taxonomy_subtree_descendant_species.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+import sys, os, re
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/taxonomy/subtree'
+test, result, _ = test_http_json_method(SUBMIT_URI,
+                                        data={"ott_id":372706},
+                                        expected_status=200,
+                                        return_bool_data=True)
+if not test:
+    sys.exit(1)
+tree = result[u'subtree']
+if tree is None or tree == '':
+    sys.stderr.write("Expected result to have a tree, but found {}".format(result))
+    sys.exit(1)
+# trying to avoid dealing with a newick parser here...
+ROOTTAXONSTR = "\)Canis_ott372706;"
+DESCENDANTTAXONSTR = "\,Canis_lycaon_ott948004\,"
+namecheck =  re.compile(ROOTTAXONSTR)
+namecheck2 = re.compile(DESCENDANTTAXONSTR)
+if re.search(namecheck,tree) is None:
+    errstr = "requested taxon{} does not appear at root of tree\n {}"
+    sys.stderr.write(errstr,ROOTTAXONSTR[1:],tree)
+    sys.exit(1)
+if re.search(namecheck2,tree) is None:
+    errstr = "expected terminal taxon {} does not appear in tree\n {}"
+    sys.stderr.write(errstr,DESCENDANTTAXONSTR[2:],tree)
+    sys.exit(1)

--- a/ws-tests/test_taxonomy_taxon2.py
+++ b/ws-tests/test_taxonomy_taxon2.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+import sys, os
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/taxonomy/taxon'
+TEST_NAME = u'Alseuosmia banksii'
+test, result, _ = test_http_json_method(SUBMIT_URI,
+                                        data={"ott_id":901642},
+                                        expected_status=200,
+                                        return_bool_data=True)
+if not test:
+    sys.exit(1)
+taxonName = result[u'ot:ottTaxonName']
+if taxonName != TEST_NAME:
+    errstr = 'Expected taxon name {} but not found in \n{}'
+    sys.stderr.write(errstr.format(TEST_NAME,taxonName))
+    sys.exit(1)
+

--- a/ws-tests/test_taxonomy_taxon_include_lineage.py
+++ b/ws-tests/test_taxonomy_taxon_include_lineage.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+import sys, os
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/taxonomy/taxon'
+test, result, _ = test_http_json_method(SUBMIT_URI,
+                                        data={"ott_id":515698, "include_lineage":"true"},
+                                        expected_status=200,
+                                        return_bool_data=True)
+if not test:
+    sys.exit(1)
+if result[u'ot:ottId'] != 515698:
+    sys.stderr.write('Incorrect ottid in returned taxon {}',format(result[u'ot:ottId']))
+    sys.exit(1)
+if u'taxonomic_lineage' not in result:
+    errstr = 'No lineage returned when expected in taxon report: {}'
+    sys.stderr.write(errstr.format(result))
+    sys.exit(1)

--- a/ws-tests/test_taxonomy_taxon_tax_sources.py
+++ b/ws-tests/test_taxonomy_taxon_tax_sources.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+import sys, os
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/taxonomy/taxon'
+test, result, _ = test_http_json_method(SUBMIT_URI,
+                                        data={"ott_id":766177},
+                                        expected_status=200,
+                                        return_bool_data=True)
+if not test:
+    sys.exit(1)
+sources = result[u'tax_sources']
+if u'ncbi:58228' not in sources:
+    errstr = 'Expected ncbi taxon id (58228) not found in tax_sources\n {}'
+    sys.stderr.write(errstr.format(sources))
+    sys.exit(1)
+if u'gbif:3189571' not in sources:
+    errstr = 'Expected gbif taxon id (3189571) not found in tax_sources\n {}'
+    sys.stderr.write(errstr.format(sources))
+    sys.exit(1)
+if u'irmng:11346207' not in sources:
+    errstr = 'Expected irmng taxon id (11346207) not found in tax_sources\n {}'
+    sys.stderr.write(errstr.format(sources))
+    sys.exit(1)
+

--- a/ws-tests/test_taxonomy_taxon_terminal_descendants.py
+++ b/ws-tests/test_taxonomy_taxon_terminal_descendants.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+import sys, os
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/taxonomy/taxon'
+r = test_http_json_method(SUBMIT_URI,
+                          'POST',
+                          data={"ott_id":1066581, "list_terminal_descendants":"true"},
+                          expected_status=200,
+                          return_bool_data=True)
+if not r[0]:
+    sys.exit(1)
+descendants = r[1][u'terminal_descendants']
+if not set([490099,1066590]).issubset(set(descendants)):
+    sys.stderr.write("Bos taurus (490099) and Bos primigenius (1066590) not returned as descendants of Bos (1066581)")
+    sys.exit(1)
+
+

--- a/ws-tests/test_tnrs_autocomplete_name.py
+++ b/ws-tests/test_tnrs_autocomplete_name.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+import sys, os, re
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/tnrs/autocomplete_name'
+SEARCHNAME = "Endoxyla"
+test, result, _= test_http_json_method(SUBMIT_URI,
+                                       data={"name":SEARCHNAME,"context_name":"All life"},
+                                       expected_status=200,
+                                       return_bool_data=True)
+if not test:
+    sys.exit(1)
+if result == []:
+    sys.stderr.write("Empty list returned\n")
+    sys.exit(1)
+NAMECHECK = re.compile(SEARCHNAME)
+for item in result:
+    uname = item[u'unique_name']
+    if uname is None:
+        sys.stderr.write("returned taxon record had no unique_name specified\n")
+        sys.exit(1)
+    elif not re.search(NAMECHECK, uname):
+        failstr = "unique name: {} of taxon record does not contain search name: {}\n"
+        sys.stderr.write(failstr.format(uname, SEARCHNAME))
+        sys.exit(1)
+sys.exit(0)
+

--- a/ws-tests/test_tnrs_contexts.py
+++ b/ws-tests/test_tnrs_contexts.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import sys, os
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/tnrs/contexts'
+test, result, _ = test_http_json_method(SUBMIT_URI,
+                                        expected_status=200,
+                                        return_bool_data=True)
+if not test:
+    sys.exit(1)
+if not (u'PLANTS' in result and u'ANIMALS' in result and
+        u'FUNGI' in result and u'LIFE' in result and u'MICROBES' in result):
+    errstr = 'Missing key in context listing \n {} \n'
+    sys.stderr.write(errstr.format(result))
+    sys.exit(1)        
+if u'Archaea' not in result[u'MICROBES']:
+    sys.stderr.write('Archaea not in context MICROBES')
+    sys.exit(1)
+if u'Arachnides' not in result[u'ANIMALS']:  # spelling?
+    sys.stderr.write('Arachnides not in context Animals')
+    sys.exit(1)

--- a/ws-tests/test_tnrs_infer_context.py
+++ b/ws-tests/test_tnrs_infer_context.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+import sys, os
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/tnrs/infer_context'
+NAMESLIST = ["Pan","Homo","Mus","Bufo","Drosophila"]
+test, result, _ = test_http_json_method(SUBMIT_URI,
+                                        data={"names":NAMESLIST},
+                                        expected_status=200,
+                                        return_bool_data=True)
+if not test:
+    sys.exit(1)
+if result[u'context_name'] != u'Animals':
+    errstr = 'Expected context = Animals, returned {}'
+    sys.stderr.write(errstr.format(result[u'context_name']))
+if result[u'ambiguous_names'] != []:
+    errstr = 'Expected no ambiguous_names, but found {}'
+    sys.stderr.write(errstr.format(result[u'ambiguous_names']))
+

--- a/ws-tests/test_tnrs_match_names.py
+++ b/ws-tests/test_tnrs_match_names.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+import sys, os
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/tnrs/match_names'
+TEST_LIST = ["Aster","Symphyotrichum","Erigeron","Barnadesia"]
+TEST_IDS = [5507594,1058735,643717,515698]
+test, result, _ = test_http_json_method(SUBMIT_URI,
+                                        data={"names":TEST_LIST},
+                                        expected_status=200,
+                                        return_bool_data=True)
+if not test:
+    sys.exit(1)
+if set(TEST_LIST) != set(result[u'matched_name_ids']):
+    errstr = "Failed to match, submitted: {}, returned {}"
+    sys.stderr.write(errstr.format(TEST_LIST,result[u'matched_name_ids']))
+MATCH_LIST = result['results']
+for match in MATCH_LIST:
+    m = match[u'matches'][0]
+    if m[u'ot:ottId'] not in TEST_IDS:
+        errstr = "bad match return {}, expected one of {}"
+        sys.stderr.write(errstr.format(m[u'ot:ottId'],str(TEST_IDS)))
+        sys.exit(1)
+    if m[u'matched_name'] not in TEST_LIST:
+        errstr = "bad match return {}, expected one of {}"
+        sys.stderr.write(errstr.format(m[u'matched_name'],str(TEST_LIST)))
+        sys.exit(1)


### PR DESCRIPTION
This pull adds 16 tests using the ws-test framework for taxomachine.  13 of these tests cover and expand on 13 of the 14 tests that are in the tests directory of this repo.  The 14th tested a deprecated namecompletion api of the tnrs, the updated version is tested.  The taxon service also tests the taxonomy_sources, since those are included by default in the output of this service.  There are 3 new tests, one for the terminal_descendants option, and two that cover two of the three tests in the test.sh script in germinator.  The third test (for tnrs_match names) was already subsumed by the version in the taxomachine tests.

All returned json is tested, but coverage still leaves a lot to be desired - if I've missed something critical, let me know. 

Also, this commit includes a copy of opentreetesting.py.  The documentation in phylesystem-api suggests this isn't necessary, but I couldn't figure out what was happening in the pythonpath, so I've included the file and suggest someone else (@mtholder?) resolve this (note that this file is already in the ws-tests for oti as well as phylesystem-api).  