### PR TITLE
Fix test returns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ dependency-reduced-pom.xml
 .project
 .settings
 *.db
+*.tmp
+.out_test*
 
 *venv
 *.pyc

--- a/ws-tests/README.md
+++ b/ws-tests/README.md
@@ -1,0 +1,13 @@
+See ws-tests/README.md in the phylesystem-api repo for information on the test harness.
+
+ws-tests/README.md in the germinator talks about the super-tester that calls
+
+The tests can be run locally against neo4j without having to go
+through apache.  peyotl needs to be installed to run the tests.  The
+command would be something like this:
+
+    ./run_tests.sh host:apihost=http://localhost:7474 host:translate=true
+
+substituting the correct port number agreeing with your neo4j
+configuration (default 7474, changed on deployed servers to 7476 for
+taxomachine or 7478 for oti).

--- a/ws-tests/opentreetesting.py
+++ b/ws-tests/opentreetesting.py
@@ -231,6 +231,6 @@ translations = [('/v2/study/', '/phylesystem/v1/study/'),
 def translate(s):
     if config('host', 'translate', 'false') == 'true':
         for (src, dst) in translations:
-            if s.startswith(src):
-                return dst + s[len(src):]
+            if src in s:
+                return s.replace(src, dst)
     return s

--- a/ws-tests/run_tests.sh
+++ b/ws-tests/run_tests.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+if ! python -c 'import peyotl' 2>/dev/null;
+then
+    echo 'peyotl must be installed to run tests'
+    exit 1
+fi
+num_t=0
+num_p=0
+failed=''
+for fn in $(ls test_*.py)
+do
+    if test $fn = skipped_test_name_here.py ; 
+    then
+        echo test $fn skipped
+    else
+        if python "$fn" $* > ".out_${fn}.txt"
+        then
+            num_p=$(expr 1 + $num_p)
+            /bin/echo -n "."
+        else
+            /bin/echo -n "F"
+            failed="$failed \n $fn"
+        fi
+        num_t=$(expr 1 + $num_t)
+    fi
+done
+echo
+echo "By default, an 's' is written for every test skipped." 
+echo "Passed or skipped $num_p out of $num_t tests."
+if test $num_t -ne $num_p
+then
+    echo "Failures: $failed"
+    exit 1
+fi

--- a/ws-tests/test_taxonomy_deprecated_taxa.py
+++ b/ws-tests/test_taxonomy_deprecated_taxa.py
@@ -3,11 +3,9 @@ import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
 SUBMIT_URI = DOMAIN + '/v2/taxonomy/deprecated_taxa'
-# currently returns an empty list
 test, result, _ = test_http_json_method(SUBMIT_URI,
-                                        expected_status=200,
-                                        expected_response=[],
-                                        return_bool_data=True)
+                          expected_status=200,
+                          return_bool_data=True)
 if not test:
     sys.exit(1)
 

--- a/ws-tests/test_taxonomy_flags.py
+++ b/ws-tests/test_taxonomy_flags.py
@@ -10,8 +10,8 @@ if not test:
     sys.exit(1)
 # result is large dictionary.  Will do a minimal test
 if u'incertae_sedis' not in result:
-    sys.stderr.write('No reported count of incertae_sedis taxa')
+    sys.stderr.write('No reported count of incertae_sedis taxa\n')
     sys.exit(1)
 if u'unclassified' not in result:
-    sys.stderr.write('No reported count of unclassified taxa')
+    sys.stderr.write('No reported count of unclassified taxa\n')
     sys.exit(1)

--- a/ws-tests/test_taxonomy_lica2.py
+++ b/ws-tests/test_taxonomy_lica2.py
@@ -18,7 +18,7 @@ if u'ot:ottId' not in lica:
     sys.exit(1)
 expectedId = 637370
 if lica[u'ot:ottId'] != expectedId:
-    errstr = 'Expected {} , found {}'
+    errstr = 'Expected {} , found {}\n'
     sys.stderr.write(errstr.format(expectedId,lica[u'ot:ottId']))
     sys.exit(1)
 

--- a/ws-tests/test_taxonomy_lica_bad_taxon.py
+++ b/ws-tests/test_taxonomy_lica_bad_taxon.py
@@ -10,24 +10,24 @@ test, result, _ = test_http_json_method(SUBMIT_URI,
 if not test:
     sys.exit(1)
 if u'lica' not in result:
-    sys.stderr.write('No lica found in result {}'.format(result))
+    sys.stderr.write('No lica found in result {}\n'.format(result))
     sys.exit(1)
 lica = result[u'lica']
 if u'ot:ottId' not in lica:
-    sys.stderr.write('No ottId found in result {}'.format(result))
+    sys.stderr.write('No ottId found in result {}\n'.format(result))
     sys.exit(1)
 expectedId = 770319
 if lica[u'ot:ottId'] != expectedId:
-    sys.stderr.write('Expected {}, found {}'.format(expectedId,lica[u'ottId']))
+    sys.stderr.write('Expected {}, found {}\n'.format(expectedId,lica[u'ottId']))
     sys.exit(1)
 if u'ott_ids_not_found' not in result:
-    errstr = "Expected to find list of ott_ids_not_found, but didn't in {}"
+    errstr = "Expected to find list of ott_ids_not_found, but didn't in {}\n"
     sys.stderr.write(errstr,result)
     sys.exit(1)
 badids = result[u'ott_ids_not_found']
 expectedBadId = 5551856
 if expectedBadId not in badids:
-    errstr = 'Expected to find {} in bad ids, found {}'
+    errstr = 'Expected to find {} in bad ids, found {}\n'
     sys.stderr.write(errstr.format(expectedBadId,badids))
     sys.exit(1)
 

--- a/ws-tests/test_taxonomy_subtree.py
+++ b/ws-tests/test_taxonomy_subtree.py
@@ -11,12 +11,12 @@ if not test:
     sys.exit(1)
 tree = result[u'subtree']
 if tree is None or tree == '':
-    sys.stderr.write("Expected result to have a tree, but found {}".format(result))
+    sys.stderr.write('Expected result to have a tree, but found {}\n'.format(result))
     sys.exit(1)
 # trying to avoid dealing with a newick parser here...
 ROOTTAXONSTR = "\)Barnadesia_ott515698;"
 namecheck =  re.compile(ROOTTAXONSTR)
 if re.search(namecheck,tree) is None:
-    errstr = "requested taxon {} does not appear at root of tree:\n {}"
+    errstr = 'requested taxon {} does not appear at root of tree:\n {}'
     sys.stderr.write(errstr,ROOTTAXONSTR[1:],tree)
     sys.exit(1)

--- a/ws-tests/test_taxonomy_subtree_descendant_species.py
+++ b/ws-tests/test_taxonomy_subtree_descendant_species.py
@@ -11,7 +11,7 @@ if not test:
     sys.exit(1)
 tree = result[u'subtree']
 if tree is None or tree == '':
-    sys.stderr.write("Expected result to have a tree, but found {}".format(result))
+    sys.stderr.write("Expected result to have a tree, but found {}\n".format(result))
     sys.exit(1)
 # trying to avoid dealing with a newick parser here...
 ROOTTAXONSTR = "\)Canis_ott372706;"
@@ -19,10 +19,10 @@ DESCENDANTTAXONSTR = "\,Canis_lycaon_ott948004\,"
 namecheck =  re.compile(ROOTTAXONSTR)
 namecheck2 = re.compile(DESCENDANTTAXONSTR)
 if re.search(namecheck,tree) is None:
-    errstr = "requested taxon{} does not appear at root of tree\n {}"
+    errstr = "requested taxon{} does not appear at root of tree\n {}\n"
     sys.stderr.write(errstr,ROOTTAXONSTR[1:],tree)
     sys.exit(1)
 if re.search(namecheck2,tree) is None:
-    errstr = "expected terminal taxon {} does not appear in tree\n {}"
+    errstr = "expected terminal taxon {} does not appear in tree\n {}\n"
     sys.stderr.write(errstr,DESCENDANTTAXONSTR[2:],tree)
     sys.exit(1)

--- a/ws-tests/test_taxonomy_taxon2.py
+++ b/ws-tests/test_taxonomy_taxon2.py
@@ -10,9 +10,12 @@ test, result, _ = test_http_json_method(SUBMIT_URI,
                                         return_bool_data=True)
 if not test:
     sys.exit(1)
+if u'ot:ottTaxonName' not in result:
+    sys.stderr.write('ot:ottTaxonName not returned in result\n')
+    sys.exit(1)
 taxonName = result[u'ot:ottTaxonName']
 if taxonName != TEST_NAME:
-    errstr = 'Expected taxon name {} but not found in \n{}'
+    errstr = 'Expected taxon name {} but not found in \n{}\n'
     sys.stderr.write(errstr.format(TEST_NAME,taxonName))
     sys.exit(1)
 

--- a/ws-tests/test_taxonomy_taxon_include_lineage.py
+++ b/ws-tests/test_taxonomy_taxon_include_lineage.py
@@ -9,6 +9,9 @@ test, result, _ = test_http_json_method(SUBMIT_URI,
                                         return_bool_data=True)
 if not test:
     sys.exit(1)
+if u'ot:ottId' not in result:
+    sys.stderr.write('ot:ottId not found in result')
+    sys.exit(1)
 if result[u'ot:ottId'] != 515698:
     sys.stderr.write('Incorrect ottid in returned taxon {}',format(result[u'ot:ottId']))
     sys.exit(1)

--- a/ws-tests/test_taxonomy_taxon_tax_sources.py
+++ b/ws-tests/test_taxonomy_taxon_tax_sources.py
@@ -9,6 +9,9 @@ test, result, _ = test_http_json_method(SUBMIT_URI,
                                         return_bool_data=True)
 if not test:
     sys.exit(1)
+if u'tax_sources' not in result:
+    sys.stderr.write('No tax_sources found in result\n')
+    sys.exit(1)
 sources = result[u'tax_sources']
 if u'ncbi:58228' not in sources:
     errstr = 'Expected ncbi taxon id (58228) not found in tax_sources\n {}'

--- a/ws-tests/test_taxonomy_taxon_terminal_descendants.py
+++ b/ws-tests/test_taxonomy_taxon_terminal_descendants.py
@@ -3,16 +3,20 @@ import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
 SUBMIT_URI = DOMAIN + '/v2/taxonomy/taxon'
-r = test_http_json_method(SUBMIT_URI,
-                          'POST',
-                          data={"ott_id":1066581, "list_terminal_descendants":"true"},
+test, result, _ = test_http_json_method(SUBMIT_URI,
+                                       data={"ott_id":1066581, 
+                                             "list_terminal_descendants":
+                                                 "true"},
                           expected_status=200,
                           return_bool_data=True)
-if not r[0]:
+if not test:
     sys.exit(1)
-descendants = r[1][u'terminal_descendants']
+if u'terminal_descendants' not in result:
+    sys.stderr.write('No terminal_descendants found in result\n')
+    sys.exit(1)
+descendants = result[u'terminal_descendants']
 if not set([490099,1066590]).issubset(set(descendants)):
-    sys.stderr.write("Bos taurus (490099) and Bos primigenius (1066590) not returned as descendants of Bos (1066581)")
+    sys.stderr.write("Bos taurus (490099) and Bos primigenius (1066590) not returned as descendants of Bos (1066581)\n")
     sys.exit(1)
 
 

--- a/ws-tests/test_tnrs_contexts.py
+++ b/ws-tests/test_tnrs_contexts.py
@@ -14,8 +14,8 @@ if not (u'PLANTS' in result and u'ANIMALS' in result and
     sys.stderr.write(errstr.format(result))
     sys.exit(1)        
 if u'Archaea' not in result[u'MICROBES']:
-    sys.stderr.write('Archaea not in context MICROBES')
+    sys.stderr.write('Archaea not in context MICROBES\n')
     sys.exit(1)
 if u'Arachnides' not in result[u'ANIMALS']:  # spelling?
-    sys.stderr.write('Arachnides not in context Animals')
+    sys.stderr.write('Arachnides not in context Animals\n')
     sys.exit(1)

--- a/ws-tests/test_tnrs_infer_context.py
+++ b/ws-tests/test_tnrs_infer_context.py
@@ -3,17 +3,21 @@ import sys, os
 from opentreetesting import test_http_json_method, config
 DOMAIN = config('host', 'apihost')
 SUBMIT_URI = DOMAIN + '/v2/tnrs/infer_context'
-NAMESLIST = ["Pan","Homo","Mus","Bufo","Drosophila"]
+NAMESLIST = ["Pan","Homo","Mus","Bufo"]
 test, result, _ = test_http_json_method(SUBMIT_URI,
                                         data={"names":NAMESLIST},
                                         expected_status=200,
                                         return_bool_data=True)
 if not test:
     sys.exit(1)
-if result[u'context_name'] != u'Animals':
-    errstr = 'Expected context = Animals, returned {}'
+if u'context_name' not in result:
+    sys.stderr.write('No context_name returned in result.\n')
+    sys.exit(1)
+if result[u'context_name'] != u'Tetrapods':
+    errstr = 'Expected context = Tetrapods, returned {}\n'
     sys.stderr.write(errstr.format(result[u'context_name']))
+    sys.exit(1)
 if result[u'ambiguous_names'] != []:
-    errstr = 'Expected no ambiguous_names, but found {}'
+    errstr = 'Expected no ambiguous_names, but found {}\n'
     sys.stderr.write(errstr.format(result[u'ambiguous_names']))
-
+    sys.exit(1)

--- a/ws-tests/test_tnrs_match_names.py
+++ b/ws-tests/test_tnrs_match_names.py
@@ -12,16 +12,17 @@ test, result, _ = test_http_json_method(SUBMIT_URI,
 if not test:
     sys.exit(1)
 if set(TEST_LIST) != set(result[u'matched_name_ids']):
-    errstr = "Failed to match, submitted: {}, returned {}"
+    errstr = "Failed to match, submitted: {}, returned {}\n"
     sys.stderr.write(errstr.format(TEST_LIST,result[u'matched_name_ids']))
+    sys.exit(1)
 MATCH_LIST = result['results']
 for match in MATCH_LIST:
     m = match[u'matches'][0]
     if m[u'ot:ottId'] not in TEST_IDS:
-        errstr = "bad match return {}, expected one of {}"
+        errstr = "bad match return {}, expected one of {}\n"
         sys.stderr.write(errstr.format(m[u'ot:ottId'],str(TEST_IDS)))
         sys.exit(1)
     if m[u'matched_name'] not in TEST_LIST:
-        errstr = "bad match return {}, expected one of {}"
+        errstr = "bad match return {}, expected one of {}\n"
         sys.stderr.write(errstr.format(m[u'matched_name'],str(TEST_LIST)))
         sys.exit(1)

--- a/ws-tests/test_tnrs_match_names2.py
+++ b/ws-tests/test_tnrs_match_names2.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+import sys, os
+from opentreetesting import test_http_json_method, config
+DOMAIN = config('host', 'apihost')
+SUBMIT_URI = DOMAIN + '/v2/tnrs/match_names'
+TEST_LIST = ["Hylobates"]
+TEST_IDS = [166552]
+test, result, _ = test_http_json_method(SUBMIT_URI,
+                                        data={"names":TEST_LIST, "context_name": 'Mammals'},
+                                        expected_status=200,
+                                        return_bool_data=True)
+if not test:
+    sys.exit(1)
+if set(TEST_LIST) != set(result[u'matched_name_ids']):
+    errstr = "Failed to match, submitted: {}, returned {}\n"
+    sys.stderr.write(errstr.format(TEST_LIST,result[u'matched_name_ids']))
+    sys.exit(1)
+MATCH_LIST = result['results']
+for match in MATCH_LIST:
+    m = match[u'matches'][0]
+    if m[u'matched_name'] not in TEST_LIST:
+        errstr = "bad match return {}, expected one of {}\n"
+        sys.stderr.write(errstr.format(m[u'matched_name'],str(TEST_LIST)))
+        sys.exit(1)
+    if m[u'ot:ottId'] not in TEST_IDS:
+        errstr = "bad match return {}, expected one of {}\n"
+        sys.stderr.write(errstr.format(m[u'ot:ottId'],str(TEST_IDS)))
+        sys.exit(1)


### PR DESCRIPTION
Mostly making sure that failing tests return an error so the test harness will report them.  Also some improved formatting of error messages.  Finally, removed the check for empty list in the deprecated_taxa test; not sure what to expect.  Added a test case for the #111  problem with Hylobates.