### PR TITLE
Build taxonomy DB directly from ott distribution

### DIFF
--- a/src/main/java/org/opentree/taxonomy/OTTFlag.java
+++ b/src/main/java/org/opentree/taxonomy/OTTFlag.java
@@ -13,11 +13,6 @@ public enum OTTFlag {
 	// dubious flags: guilty until proven innocent
 
 	/**
-	 * Higher taxa with zero species-level children.
-	 */
-	BARREN ("barren", false),
-
-	/**
 	 * Things with the string "environmental" in their name.
 	 */
 	ENVIRONMENTAL ("environmental", false),
@@ -29,6 +24,11 @@ public enum OTTFlag {
 	ENVIRONMENTAL_INHERITED ("environmental_inherited", false),
 
 	/**
+	 * Higher taxa with zero species-level children.
+	 */
+	BARREN ("barren", true),
+
+	/**
 	 * Extinct taxa; replaced extinct_direct
 	 */
 	EXTINCT ("extinct", true),
@@ -37,13 +37,13 @@ public enum OTTFlag {
 	 * Extinct taxa. Replaced by 'extinct'
 	 */
 	 @Deprecated
-	EXTINCT_DIRECT ("extinct_direct", true), // TODO: should these be hidden?
-
+	EXTINCT_DIRECT ("extinct_direct", true),
+    
 	/**
 	 * Extinct taxa?
 	 */
-	EXTINCT_INHERITED ("extinct_inherited", true), // TODO: should these be hidden?
-
+	EXTINCT_INHERITED ("extinct_inherited", true),
+    
 	/**
 	 * Low-rank children of high-rank taxa (e.g. genus child of class).
 	 * Replaces major_rank_conflict_direct

--- a/src/main/java/org/opentree/taxonomy/OTTFlag.java
+++ b/src/main/java/org/opentree/taxonomy/OTTFlag.java
@@ -67,7 +67,7 @@ public enum OTTFlag {
      * (pseudo-taxa in NCBI with the string "unclassified" in their name).
      * New 2014-04-26
 	 */
-	UNCLASSIFIED ("unclassified", false),
+	UNCLASSIFIED ("unclassified", true),
 
 	/**
 	 * Taxa with the string "unclassified" in their name, but which
@@ -80,7 +80,7 @@ public enum OTTFlag {
 	/**
 	 * Descendants of UNCLASSIFIED taxa.
 	 */
-	UNCLASSIFIED_INHERITED ("unclassified_inherited", false),
+	UNCLASSIFIED_INHERITED ("unclassified_inherited", true),
 
 	/**
 	 * Viruses.

--- a/src/main/java/org/opentree/taxonomy/OTTFlag.java
+++ b/src/main/java/org/opentree/taxonomy/OTTFlag.java
@@ -24,7 +24,37 @@ public enum OTTFlag {
 	ENVIRONMENTAL_INHERITED ("environmental_inherited", false),
 
 	/**
-	 * Higher taxa with zero species-level children.
+	 * Viruses.
+	 */
+	VIRAL ("viral", false),
+
+	/**
+	 * Taxa that have been intentionally hidden (by a curator? for some reason other than those listed in other flags?).
+	 */
+	HIDDEN ("hidden", false),
+
+	/**
+	 * Taxa contained within taxa have been intentionally hidden (by a curator? for some reason other than those listed in other flags?).
+	 */
+	HIDDEN_INHERITED ("hidden_inherited", false),
+
+	/**
+	 * Taxa with the string "unclassified" in their name, but which
+	 * have no children and thus are (hopefully) no longer a
+	 * container.
+     * 2014-04-26 DEPRECATED, these are now just labeled "not_otu".
+	 */
+	UNCLASSIFIED_DIRECT ("unclassified_direct", false),
+
+	 /**
+	 Treat same as incertae_sedis, merged, and inconsistent - the 'taxon' was formerly a 'bucket' but is now empty and is preserved as a placeholder.
+	*/
+	WAS_CONTAINER ("was_container", false),
+
+	// ===== flags not designating suppression
+
+	/**
+	 * Higher taxa with zero species-level children. (feedback #107)
 	 */
 	BARREN ("barren", true),
 
@@ -70,34 +100,9 @@ public enum OTTFlag {
 	UNCLASSIFIED ("unclassified", true),
 
 	/**
-	 * Taxa with the string "unclassified" in their name, but which
-	 * have no children and thus are (hopefully) no longer a
-	 * container.
-     * 2014-04-26 DEPRECATED, these are now just labeled "not_otu".
-	 */
-	UNCLASSIFIED_DIRECT ("unclassified_direct", false),
-
-	/**
 	 * Descendants of UNCLASSIFIED taxa.
 	 */
 	UNCLASSIFIED_INHERITED ("unclassified_inherited", true),
-
-	/**
-	 * Viruses.
-	 */
-	VIRAL ("viral", false),
-
-	/**
-	 * Taxa that have been intentionally hidden (by a curator? for some reason other than those listed in other flags?).
-	 */
-	HIDDEN ("hidden", false),
-
-	/**
-	 * Taxa contained within taxa have been intentionally hidden (by a curator? for some reason other than those listed in other flags?).
-	 */
-	HIDDEN_INHERITED ("hidden_inherited", false),
-
-	// ===== flags not designating suppression
 
 	/**
 	 * Taxa that have been manually edited.
@@ -186,12 +191,8 @@ public enum OTTFlag {
 	Taxon is hidden, children aren't. Taxon may be revived if it's learned later
 	that the it is actually different.
 	*/
-	 MERGED ("merged", true),
-
-	 /**
-	 Treat same as incertae_sedis, merged, and inconsistent - the 'taxon' was formerly a 'bucket' but is now empty and is preserved as a placeholder.
-	*/
-	WAS_CONTAINER ("was_container", false);
+	 MERGED ("merged", true)
+    ;
 
 	public final String label;
 	public final boolean includeInPrefIndexes;


### PR DESCRIPTION
Carries out building both the 1) taxonomy and 2) contexts in one fell swoop.

Seems like a good idea: 1) second step (making contexts) cannot be forgotten (which leads to [issues](https://github.com/OpenTreeOfLife/feedback/issues/147)), and 2) version of the taxonomy is taken directly from ott files (and not manually typed in, as is now the case).

Also nice to get it done in one go, as it takes so long to complete.

Run as:

```java -jar target/taxomachine-0.0.1-SNAPSHOT-jar-with-dependencies.jar buildott path_to_ott```

I've tested this out with a subsetted taxonomy (Vertebrata) and it works correctly.