### PR TITLE
Add source id lookup feature to taxon_info method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ db: taxomachine.db
 TAXONOMY=ott
 $(TAXONOMY):
 	curl http://files.opentreeoflife.org/ott/current/ott.tgz >ott.tgz
-	rmdir -f ott.tmp; mkdir ott.tmp && tar xzf ../ott.tgz && mv * ../$(TAXONOMY)
+	rm -rf ott.tmp && mkdir ott.tmp && cd ott.tmp && tar xzf ../ott.tgz && mv * ../$(TAXONOMY)
 
 SOURCES=$(shell echo `find src -name "*.java"`)
 STANDALONE=target/taxomachine-0.0.1-SNAPSHOT-jar-with-dependencies.jar
@@ -38,7 +38,7 @@ TARBALL=$(shell echo "taxomachine-`date '+%Y%m%d%n'`.db.tgz")
 tarball: $(TARBALL)
 $(TARBALL): taxomachine.db
 	echo $(TARBALL)
-	tar -C $< -czf $@ .
+	tar -czf $@ -C $< .
 
 push-devapi: $(TARBALL)
 	scp $< devapi:downloads/$(TARBALL)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,99 @@
+# This Makefile does two things
+#   1. Creates a taxomachine database ready for deployment (needs lots of RAM)
+#   2. Sets up a server running locally for testing purposes
+
+#  $^ = all prerequisites
+#  $< = first prerequisite
+#  $@ = file name of target
+
+# 1. Create database
+
+db: taxomachine.db
+
+# This one will have to be configured manually for development versions of the taxonomy.
+# Get 'released' taxonomy from http://files.opentreeoflife.org/ott/current/ott.tgz
+TAXONOMY=ott
+$(TAXONOMY):
+	curl http://files.opentreeoflife.org/ott/current/ott.tgz >ott.tgz
+	rmdir -f ott.tmp; mkdir ott.tmp && tar xzf ../ott.tgz && mv * ../$(TAXONOMY)
+
+SOURCES=$(shell echo `find src -name "*.java"`)
+STANDALONE=target/taxomachine-0.0.1-SNAPSHOT-jar-with-dependencies.jar
+MEM=-Xmx30g
+
+$(STANDALONE): $(SOURCES)
+	./compile_standalone.sh -q
+
+taxomachine.db: $(STANDALONE) $(TAXONOMY)/version.txt
+	if [ -e $@ ]; then rm -rf $@.previous; mv -f $@ $@.previous; fi
+	echo sourcename = $(TAXONOMY)`cat $(TAXONOMY)/version.txt`
+	java $(MEM) -XX:-UseConcMarkSweepGC -jar $(STANDALONE) \
+	  loadtaxsyn $(TAXONOMY)`cat $(TAXONOMY)/version.txt` \
+	     $(TAXONOMY)/taxonomy.tsv $(TAXONOMY)/synonyms.tsv $@
+	java $(MEM) -XX:-UseConcMarkSweepGC -jar $(STANDALONE) makecontexts $@
+	java $(MEM) -XX:-UseConcMarkSweepGC -jar $(STANDALONE) makegenusindexes $@
+
+TARBALL=$(shell echo "taxomachine-`date '+%Y%m%d%n'`.db.tgz")
+
+tarball: $(TARBALL)
+$(TARBALL): taxomachine.db
+	echo $(TARBALL)
+	tar -C $< -czf $@ .
+
+push-devapi: $(TARBALL)
+	scp $< devapi:downloads/$(TARBALL)
+
+# 2. Local testing
+# maybe should be NEO=../../neo4j-taxomachine ?
+
+NEO=neo4j-community-1.9.5
+PLUGIN=target/taxomachine-neo4j-plugins-0.0.1-SNAPSHOT.jar
+SETTINGS=host:apihost=http://localhost:7476 host:translate=true
+
+neo4j: $(NEO)
+$(NEO):
+	curl http://files.opentreeoflife.org/neo4j/neo4j-community-1.9.5.tar.gz >neo4j-community-1.9.5.tar.gz
+	tar xzvf neo4j-community-1.9.5.tar.gz
+	sed -i ".bak" -e s+7474+7476+ -e s+7473+7475+ $(NEO)/conf/neo4j-server.properties
+
+push-local: $(TARBALL) $(NEO)
+	if [ -e $(NEO)/data/graph.db ]; then \
+	  rm -rf $(NEO)/data/graph.db.previous; \
+	  mv -f $(NEO)/data/graph.db $(NEO)/data/graph.db.previous; fi
+	mkdir $(NEO)/data/graph.db
+	(cd $(NEO)/data/graph.db; pwd; tar xzf ../../../$(TARBALL))
+
+compile: $(PLUGIN)
+
+$(PLUGIN): $(SOURCES)
+	./compile_server_plugins.sh -q
+
+run: .running
+
+.running: $(PLUGIN)
+	$(NEO)/bin/neo4j stop
+	rm -f .running
+	cp -p $(PLUGIN) $(NEO)/plugins/
+	$(NEO)/bin/neo4j start
+	touch .running
+
+stop:
+	$(NEO)/bin/neo4j stop
+	rm -f .running
+
+test-v3: .running
+	cd ws-tests; \
+	for test in test_v3*.py; do \
+	  echo $$test; \
+	  python $$test $(SETTINGS); \
+	done 
+
+test-v2: .running
+	cd ws-tests; \
+	for test in test_v2*.py; do \
+	  echo $$test; \
+	  python $$test $(SETTINGS); \
+	done
+
+test: test-v2 test-v3
+

--- a/TESTING.md
+++ b/TESTING.md
@@ -24,11 +24,13 @@ TAXOMACHINE_SERVER=localhost:7476/db/data && export TAXOMACHINE_SERVER && ./test
 
 See [open tree testing overview](https://github.com/OpenTreeOfLife/germinator/blob/master/TESTING.md)
 
-Tests are invoked from the ws-tests directory, e.g.
-
+For local testing:
 ```
-cd ws-tests
-./run_tests.sh host:apihost=https://devapi.opentreeoflife.org
+../germinator/ws-tests/run_tests.sh -t . http://localhost:7474 host:translate=true
 ```
+(ignore the warning about https:)
 
-These tests will be invoked from the overall web API test script (in the germinator repo).
+To test as deployed on devapi:
+```
+../germinator/ws-tests/run_tests.sh -t . https://devapi.opentreeoflife.org
+```

--- a/compile_server_plugins.sh
+++ b/compile_server_plugins.sh
@@ -1,1 +1,1 @@
-mvn -f pom.serverplugins.xml clean compile package jar:jar
+mvn $* -f pom.serverplugins.xml clean compile package jar:jar

--- a/compile_standalone.sh
+++ b/compile_standalone.sh
@@ -1,1 +1,1 @@
-mvn clean compile assembly:single
+mvn $* clean compile assembly:single

--- a/src/main/java/org/opentree/taxonomy/MainRunner.java
+++ b/src/main/java/org/opentree/taxonomy/MainRunner.java
@@ -239,7 +239,8 @@ public class MainRunner {
         System.out.println("life node: " + lifeNode);
 
         if (args[0].equals("loadtaxsyn")) { 
-            System.out.println("loading taxonomy from " + filename + " and synonym file " + synonymfile + " to " + graphname);
+            System.out.format("loading taxonomy %s from %s and synonym file %s to %s\n",
+                              sourcename, filename, synonymfile, graphname);
             //this will create the ott relationships
             tlo.setAddSynonyms(true);
             tlo.setCreateOTTIdIndexes(true);

--- a/src/main/java/org/opentree/taxonomy/Taxonomy.java
+++ b/src/main/java/org/opentree/taxonomy/Taxonomy.java
@@ -317,9 +317,8 @@ public class Taxonomy {
 			metadata.put(key, metaNode.getProperty(key));
 		}
 
-        // As of 2016-03-24, we have source, author, and weburl fields.
         // Source is something like "ott2.9draft12".
-        // In treemachine, taxonomy metadata in treemachine has "name" and "version" fields which 
+        // In treemachine, taxonomy metadata has "name" and "version" fields which 
         // concatenated would be the "source" field.
         String source = (String) metadata.get("source");
         Matcher m = deversioner.matcher(source);
@@ -328,11 +327,13 @@ public class Taxonomy {
             String version = m.group(2); // e.g. 2.9draft5
             String majorminor = m.group(3); // e.g. 2.9
             metadata.put("name", name);
-            metadata.put("version", m.group(3));
+            metadata.put("version", majorminor);
             String weburl = (String) metadata.get("weburl");
             if (weburl.equals("https://github.com/OpenTreeOfLife/opentree/wiki/Open-Tree-Taxonomy"))
                 metadata.put("weburl", "https://tree.opentreeoflife.org/about/taxonomy-version/" + name + majorminor);
-        }
+        } else
+            // shouldn't happen
+            metadata.put("name", source);
 		return metadata;
 	}
 

--- a/src/main/java/org/opentree/taxonomy/TaxonomyLoaderOTT.java
+++ b/src/main/java/org/opentree/taxonomy/TaxonomyLoaderOTT.java
@@ -239,6 +239,7 @@ public class TaxonomyLoaderOTT extends TaxonomyLoaderBase {
 		setupIndexes(); // have to call this here instead of on construction so that we don't make indexes we're not going to use
 		
 		this.sourceName = sourcename;
+        System.out.format("sourcename = %s\n", sourcename);
 		String str = "";
 		int count = 0;
 		ArrayList<String> templines = new ArrayList<String>();

--- a/src/main/java/org/opentree/taxonomy/TaxonomyLoaderOTT.java
+++ b/src/main/java/org/opentree/taxonomy/TaxonomyLoaderOTT.java
@@ -50,6 +50,7 @@ public class TaxonomyLoaderOTT extends TaxonomyLoaderBase {
 
 	// all taxa by other info
 	Index<Node> taxaByOTTId;
+	Index<Node> taxaBySourceId;
 	Index<Node> taxaByFlag;
 
 	// all taxa rank-based
@@ -100,6 +101,7 @@ public class TaxonomyLoaderOTT extends TaxonomyLoaderBase {
 	private boolean buildPreferredIndexes = true; // requires that preferred rels are also built.
 	private boolean buildPreferredRels = true;
 	private boolean createOTTIdIndexes = true;
+	private boolean createSourceIdIndexes = true;
 	
 	// ========================================
 	
@@ -543,6 +545,14 @@ public class TaxonomyLoaderOTT extends TaxonomyLoaderBase {
 			taxaByOTTId.add(tnode, OTVocabularyPredicate.OT_OTT_ID.propertyName(), Long.valueOf(inputId));
 		}
 		
+		if (createSourceIdIndexes) {
+            for (String source : inputSources.split(","))
+                if (source.contains(":") &&
+                    !source.endsWith(":") &&
+                    !source.startsWith("http"))
+                    taxaBySourceId.add(tnode, TaxonomyProperty.SOURCE_ID.propertyName(), source);
+		}
+		
 		if (addSynonyms) {
 			taxaByNameOrSynonym.add(tnode, OTVocabularyPredicate.OT_OTT_TAXON_NAME.propertyName(), inputName);
 //			taxaByNameOrSynonym.add(tnode, TaxonomyProperty.NAME.propertyName(), inputName);
@@ -687,6 +697,11 @@ public class TaxonomyLoaderOTT extends TaxonomyLoaderBase {
 		// only for ott id option
 		if (createOTTIdIndexes) {
 			taxaByOTTId = ALLTAXA.getNodeIndex(TaxonomyNodeIndex.TAXON_BY_OTT_ID);
+		}
+
+		// only for ott id option
+		if (createSourceIdIndexes) {
+			taxaBySourceId = ALLTAXA.getNodeIndex(TaxonomyNodeIndex.TAXON_BY_SOURCE_ID);
 		}
 
 		// only for preferred option

--- a/src/main/java/org/opentree/taxonomy/constants/TaxonomyProperty.java
+++ b/src/main/java/org/opentree/taxonomy/constants/TaxonomyProperty.java
@@ -27,6 +27,16 @@ public enum TaxonomyProperty implements OTPropertyPredicate {
 	SOURCE ("source", String.class),
 
 	/**
+	 * A taxonomic source of this taxon.
+	 */
+	SOURCE_ID ("source_id", String.class),
+
+	/**
+	 * The current property for taxonomic sources
+	 */
+	INPUT_SOURCES ("input_sources", String.class),
+	
+	/**
 	 * A unique taxonomic name for this taxon, determined during taxonomy compilation.
 	 */
 	UNIQUE_NAME ("uniqname", String.class),
@@ -45,11 +55,6 @@ public enum TaxonomyProperty implements OTPropertyPredicate {
 	 * The original source information for this deprecated taxon.
 	 */
 	SOURCE_INFO ("source_info", String.class),
-	
-	/**
-	 * The current property for taxonomic sources
-	 */
-	INPUT_SOURCES ("input_sources", String.class),
 	
 	/**
 	 * Whether or not this node represents a deprecated taxon. Assumed to be false if absent.

--- a/src/main/java/org/opentree/taxonomy/contexts/TaxonomyNodeIndex.java
+++ b/src/main/java/org/opentree/taxonomy/contexts/TaxonomyNodeIndex.java
@@ -38,6 +38,9 @@ public enum TaxonomyNodeIndex implements NodeIndexDescription {
 	/** Records all taxa. Field is OTVocabularyPredicate.OT_OTT_ID and key is ott id. */
     TAXON_BY_OTT_ID 			("taxNodesByOTTId"),
 
+	/** Records all taxa. Field is OTVocabularyPredicate.OT_OTT_ID and key is ott id. */
+    TAXON_BY_SOURCE_ID 			("taxNodesBySourceId"),
+
 	/** Records all taxa. Field is OTVocabularyPredicate.OT_OTT_TAXON_NAME and key is synonymous name. */
     TAXON_BY_SYNONYM            ("taxNodesBySyn"),
     

--- a/src/main/java/org/opentree/taxonomy/plugins/taxonomy_v3.java
+++ b/src/main/java/org/opentree/taxonomy/plugins/taxonomy_v3.java
@@ -207,6 +207,28 @@ public class taxonomy_v3 extends ServerPlugin {
     	return OTRepresentationConverter.convert(results);
     }
 
+    @Description("TEMPORARY - look up by source id.")
+    @PluginTarget(GraphDatabaseService.class)
+    public Representation get_by_source_id (@Source GraphDatabaseService graphDb,
+
+    		@Description("The source id of the taxon of interest, e.g. ncbi:417950.")
+    		@Parameter(name="source_id", optional=false)
+    		String sourceId)
+        throws BadInputException
+    {
+    	HashMap<String, Object> results = new HashMap<String, Object>();
+
+    	Taxonomy tax = new Taxonomy(graphDb);
+    	Taxon match = tax.getTaxonForSourceId(sourceId);
+
+    	if (match != null) {
+    		results = (HashMap<String, Object>) getTaxonInfo(match, false, false);
+    	} else {
+    		throw new BadInputException("The source id " + sourceId + " could not be found");
+    	}
+    	return OTRepresentationConverter.convert(results);
+    }
+
     @Description("Return a list of all taxonomic flags used in this database, including the number of taxa to which each flag "
     		+ "has been assigned.")
     @PluginTarget(GraphDatabaseService.class)

--- a/src/main/java/org/opentree/taxonomy/plugins/taxonomy_v3.java
+++ b/src/main/java/org/opentree/taxonomy/plugins/taxonomy_v3.java
@@ -165,8 +165,13 @@ public class taxonomy_v3 extends ServerPlugin {
     public Representation taxon_info (@Source GraphDatabaseService graphDb,
 
     		@Description("The OTT id of the taxon of interest.")
-    		@Parameter(name="ott_id", optional=false)
+    		@Parameter(name="ott_id", optional=true)
     		Long ottId,
+
+    		@Description("The source id of the taxon of interest, e.g. ncbi:417950. "
+                         + "Either ott_id or source_id, but not both, must be supplied.")
+    		@Parameter(name="source_id", optional=true)
+    		String sourceId,
 
     		@Description("Provide a list of terminal OTT ids contained by this taxon.")
     		@Parameter(name="include_terminal_descendants", optional=true)
@@ -186,11 +191,17 @@ public class taxonomy_v3 extends ServerPlugin {
     {
 
     	listDescendants = listDescendants == null ? false : listDescendants;
+        if ((ottId == null) == (sourceId == null))
+            throw new BadInputException("Please provide either ott_id or source source_id, but not both.");
 
     	HashMap<String, Object> results = new HashMap<String, Object>();
 
     	Taxonomy tax = new Taxonomy(graphDb);
-    	Taxon match = tax.getTaxonForOTTId(ottId);
+    	Taxon match;
+        if (ottId != null)
+            match = tax.getTaxonForOTTId(ottId);
+        else
+            match = tax.getTaxonForSourceId(sourceId);
 
     	if (match != null) {
     		results = (HashMap<String, Object>) getTaxonInfo(match, includeLineage, includeChildren);
@@ -200,32 +211,11 @@ public class taxonomy_v3 extends ServerPlugin {
                                     match.getTaxonomyTerminals(tipFormat));
     	    	}
 
-    	} else {
+    	} else if (ottId != null)
     		throw new BadInputException("The OTT id " + String.valueOf(ottId) + " could not be found");
-    	}
-
-    	return OTRepresentationConverter.convert(results);
-    }
-
-    @Description("TEMPORARY - look up by source id.")
-    @PluginTarget(GraphDatabaseService.class)
-    public Representation get_by_source_id (@Source GraphDatabaseService graphDb,
-
-    		@Description("The source id of the taxon of interest, e.g. ncbi:417950.")
-    		@Parameter(name="source_id", optional=false)
-    		String sourceId)
-        throws BadInputException
-    {
-    	HashMap<String, Object> results = new HashMap<String, Object>();
-
-    	Taxonomy tax = new Taxonomy(graphDb);
-    	Taxon match = tax.getTaxonForSourceId(sourceId);
-
-    	if (match != null) {
-    		results = (HashMap<String, Object>) getTaxonInfo(match, false, false);
-    	} else {
+        else
     		throw new BadInputException("The source id " + sourceId + " could not be found");
-    	}
+
     	return OTRepresentationConverter.convert(results);
     }
 

--- a/ws-tests/test_v3_taxonomy_source_id.py
+++ b/ws-tests/test_v3_taxonomy_source_id.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+from check import *
+
+TEST_NAME = u'Alseuosmia banksii'
+
+def check_result(x):
+    return x[u'name'] == TEST_NAME
+
+status = 0
+
+status += \
+simple_test('/v3/taxonomy/taxon_info',
+            {u'source_id': u'ncbi:490635'},
+            check_extended_taxon_blob,
+            check_result)
+
+sys.exit(status)


### PR DESCRIPTION
Addresses #97. You can now say "source_id": "ncbi:1234" as a substitute for "ott_id":... in the taxonomy/taxon_info method. Running on devapi; a new taxomachine database was required (and will have to be copied over to api). I wanted to wait until this was reviewed and deployed before updating the documentation.
