### PR TITLE
Implement id aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ target
 
 .DS_Store
 neo4j-community-1.9.5
+neo4j-community-1.9.5-unix.tar.gz
 *.tgz
 ott
 aster

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@
 
 # 1. Create database
 
+TARBALL=$(shell echo "taxomachine-`date '+%Y%m%d%n'`.db.tgz")
+
 all: $(TARBALL)
 
 db: taxomachine.db
@@ -23,6 +25,8 @@ SOURCES=$(shell echo `find src -name "*.java"`)
 STANDALONE=target/taxomachine-0.0.1-SNAPSHOT-jar-with-dependencies.jar
 MEM=-Xmx30g
 
+standalone: $(STANDALONE)
+
 $(STANDALONE): $(SOURCES)
 	./compile_standalone.sh -q
 
@@ -35,8 +39,6 @@ taxomachine.db: $(STANDALONE) $(TAXONOMY)/version.txt
 	java $(MEM) -XX:-UseConcMarkSweepGC -jar $(STANDALONE) makecontexts $@
 	java $(MEM) -XX:-UseConcMarkSweepGC -jar $(STANDALONE) makegenusindexes $@
 
-TARBALL=$(shell echo "taxomachine-`date '+%Y%m%d%n'`.db.tgz")
-
 tarball: $(TARBALL)
 $(TARBALL): taxomachine.db
 	echo $(TARBALL)
@@ -48,22 +50,28 @@ push-devapi: $(TARBALL)
 # 2. Local testing
 # maybe should be NEO=../../neo4j-taxomachine ?
 
-NEO=neo4j-community-1.9.5
+NEO_ROOT=neo4j-community-1.9.5
 PLUGIN=target/taxomachine-neo4j-plugins-0.0.1-SNAPSHOT.jar
 SETTINGS=host:apihost=http://localhost:7476 host:translate=true
+NEOFOO=$(NEO_ROOT)/conf/neo4j-server.properties
+NEOTAR=neo4j-community-1.9.5-unix.tar.gz
 
-neo4j: $(NEO)
-$(NEO):
-	curl http://files.opentreeoflife.org/neo4j/neo4j-community-1.9.5.tar.gz >neo4j-community-1.9.5.tar.gz
-	tar xzvf neo4j-community-1.9.5.tar.gz
-	sed -i ".bak" -e s+7474+7476+ -e s+7473+7475+ $(NEO)/conf/neo4j-server.properties
+neo4j: $(NEOFOO)
+$(NEOFOO): $(NEOTAR)
+	tar xzf $(NEOTAR)
+	cp -p $(NEO_ROOT)/conf/neo4j-server.properties $(NEO_ROOT)/conf/neo4j-server.properties.orig
+	sed -e s+7474+7476+ -e s+7473+7475+ $(NEO_ROOT)/conf/neo4j-server.properties >sed.tmp
+	mv sed.tmp $(NEO_ROOT)/conf/neo4j-server.properties
 
-push-local: $(TARBALL) $(NEO)
-	if [ -e $(NEO)/data/graph.db ]; then \
-	  rm -rf $(NEO)/data/graph.db.previous; \
-	  mv -f $(NEO)/data/graph.db $(NEO)/data/graph.db.previous; fi
-	mkdir $(NEO)/data/graph.db
-	(cd $(NEO)/data/graph.db; pwd; tar xzf ../../../$(TARBALL))
+$(NEOTAR):
+	curl http://files.opentreeoflife.org/neo4j/neo4j-community-1.9.5.tar.gz >$(NEOTAR)
+
+push-local: $(TARBALL) $(NEOFOO)
+	if [ -e $(NEO_ROOT)/data/graph.db ]; then \
+	  rm -rf $(NEO_ROOT)/data/graph.db.previous; \
+	  mv -f $(NEO_ROOT)/data/graph.db $(NEO_ROOT)/data/graph.db.previous; fi
+	mkdir $(NEO_ROOT)/data/graph.db
+	(cd $(NEO_ROOT)/data/graph.db; pwd; tar xzf ../../../$(TARBALL))
 
 compile: $(PLUGIN)
 
@@ -73,14 +81,14 @@ $(PLUGIN): $(SOURCES)
 run: .running
 
 .running: $(PLUGIN)
-	$(NEO)/bin/neo4j stop
+	$(NEO_ROOT)/bin/neo4j stop
 	rm -f .running
-	cp -p $(PLUGIN) $(NEO)/plugins/
-	$(NEO)/bin/neo4j start
+	cp -p $(PLUGIN) $(NEO_ROOT)/plugins/
+	$(NEO_ROOT)/bin/neo4j start
 	touch .running
 
 stop:
-	$(NEO)/bin/neo4j stop
+	$(NEO_ROOT)/bin/neo4j stop
 	rm -f .running
 
 test-v3: .running

--- a/compile_server_plugins.sh
+++ b/compile_server_plugins.sh
@@ -1,1 +1,1 @@
-mvn $* -f pom.serverplugins.xml clean compile package jar:jar
+mvn -q $* -f pom.serverplugins.xml clean compile package jar:jar

--- a/compile_standalone.sh
+++ b/compile_standalone.sh
@@ -1,1 +1,1 @@
-mvn $* clean compile assembly:single
+mvn -q $* clean compile assembly:single

--- a/src/main/java/org/opentree/taxonomy/MainRunner.java
+++ b/src/main/java/org/opentree/taxonomy/MainRunner.java
@@ -54,6 +54,8 @@ public class MainRunner {
      *  1. taxonomy.tsv
      *  2. synonyms.tsv
      *  3. version.txt
+     * Optional:
+	 *  4. forwads.tsv  (synonyms and version should be optional as well)
      *  Will create a DB called 'ott_v[ottVersion].db' e.g. 'ott_v2.8draft5.db'
      *  Finally, it will build the contexts
     */
@@ -78,6 +80,7 @@ public class MainRunner {
         String ottVersion = "";
         String taxFile = ottDir + File.separator + "taxonomy.tsv";
         String synFile = ottDir + File.separator + "synonyms.tsv";
+        String aliasFile = ottDir + File.separator + "forwards.tsv";
         String versionFile = ottDir + File.separator + "version.txt";
         String graphName = "";
         
@@ -126,7 +129,7 @@ public class MainRunner {
         tlo.setAddSynonyms(true);
         tlo.setCreateOTTIdIndexes(true);
         tlo.setbuildPreferredIndexes(true);
-        tlo.loadOTTIntoGraph(ottVersion, taxFile, synFile);
+        tlo.loadOTTIntoGraph(ottVersion, taxFile, synFile, aliasFile);
         
         // Build contexts
         TaxonomySynthesizer te = null;
@@ -139,12 +142,15 @@ public class MainRunner {
         return 0;
     }
     
+	// Parse command line argument sequence
+
     public void taxonomyLoadParser(String[] args) throws FileNotFoundException, IOException {
 
         String graphname = "";
         String sourcename = "";
         String filename = "";
         String synonymfile = "";
+        String aliasfile = null;
         if (args[0].equals("adddeprecated")) {
             if (args.length != 3) {
                 System.out
@@ -164,15 +170,21 @@ public class MainRunner {
                 graphname = args[3];
             } */
         } else if (args[0].equals("inittaxsyn") || args[0].equals("addtaxsyn") || args[0].equals("loadtaxsyn")) {
-            if (args.length != 5) {
+			switch(args.length) {
+			case 6:
+				aliasfile = args[4];
+                graphname = args[5];
+				break;
+			case 5:
+                graphname = args[4];
+				break;
+            default:
                 System.out.println("arguments should be: sourcename filename synonymfile graphdbfolder");
                 return;
-            } else {
-                sourcename = args[1];
-                filename = args[2];
-                synonymfile = args[3];
-                graphname = args[4];
             }
+			sourcename = args[1];
+			filename = args[2];
+			synonymfile = args[3];
         }
 
         taxdb = new GraphDatabaseAgent(graphname);
@@ -238,14 +250,15 @@ public class MainRunner {
         Node lifeNode = tlo.getTaxonomyRootNode();
         System.out.println("life node: " + lifeNode);
 
-        if (args[0].equals("loadtaxsyn")) { 
+        if (args[0].equals("loadtaxsyn")) {
             System.out.format("loading taxonomy %s from %s and synonym file %s to %s\n",
                               sourcename, filename, synonymfile, graphname);
             //this will create the ott relationships
             tlo.setAddSynonyms(true);
+            tlo.setAddAliases(aliasfile != null);
             tlo.setCreateOTTIdIndexes(true);
             tlo.setbuildPreferredIndexes(true);
-            tlo.loadOTTIntoGraph(sourcename, filename, synonymfile);
+            tlo.loadOTTIntoGraph(sourcename, filename, synonymfile, aliasfile);
 
         } else if (args[0].equals("adddeprecated")) { 
             System.out.println("adding deprecated taxa from " + filename + " to " + graphname);

--- a/src/main/java/org/opentree/taxonomy/TaxonomyLoaderOTT.java
+++ b/src/main/java/org/opentree/taxonomy/TaxonomyLoaderOTT.java
@@ -1,6 +1,8 @@
 package org.opentree.taxonomy;
 
 import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.List;
@@ -167,7 +169,8 @@ public class TaxonomyLoaderOTT extends TaxonomyLoaderBase {
 		int n = 0;
 		boolean observedHeaderLine = false;
 		try {
-			BufferedReader reader = new BufferedReader(new FileReader(deprecatedFile));
+			BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(deprecatedFile),
+																			 "UTF-8"));
 			String curStr;
 			while ((curStr = reader.readLine()) != null) {
 				
@@ -287,7 +290,8 @@ public class TaxonomyLoaderOTT extends TaxonomyLoaderBase {
 		
 		// process the incoming lines in batches
 		try {
-			BufferedReader br = new BufferedReader(new FileReader(filename));
+			BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(filename),
+																		 "UTF-8"));
 			while ((str = br.readLine()) != null) {
 				count += 1;
 				templines.add(str);
@@ -401,7 +405,8 @@ public class TaxonomyLoaderOTT extends TaxonomyLoaderBase {
 		System.out.println("getting synonyms");
 		ottIdToSynonymNamesMap = new HashMap<Long, ArrayList<String>>();
 		try {
-			BufferedReader sbr = new BufferedReader(new FileReader(synonymfile));
+			BufferedReader sbr = new BufferedReader(new InputStreamReader(new FileInputStream(synonymfile),
+																		  "UTF-8"));
 			String str;
 			while ((str = sbr.readLine()) != null) {
 						

--- a/src/main/java/org/opentree/taxonomy/contexts/ContextDescription.java
+++ b/src/main/java/org/opentree/taxonomy/contexts/ContextDescription.java
@@ -27,7 +27,7 @@ public enum ContextDescription {
     SAR                 ("SAR group",       ContextGroup.MICROBES,  "SAR",              "SAR",              5246039L,   Nomenclature.Undefined),
     ARCHAEA             ("Archaea",         ContextGroup.MICROBES,  "Archaea",          "Archaea",          996421L,    Nomenclature.ICNP),
     EXCAVATA            ("Excavata",        ContextGroup.MICROBES,  "Excavata",         "Excavata",         2927065L,   Nomenclature.Undefined),
-    AMOEBAE             ("Amoebae",         ContextGroup.MICROBES,  "Amoebae",          "Amoebozoa",        1064655L,   Nomenclature.ICZN),
+    AMOEBAE             ("Amoebozoa",       ContextGroup.MICROBES,  "Amoebae",          "Amoebozoa",        1064655L,   Nomenclature.ICZN),
     CENTROHELIDA        ("Centrohelida",    ContextGroup.MICROBES,  "Centrohelida",     "Centrohelida",     755852L,    Nomenclature.ICZN),
     HAPTOPHYTA          ("Haptophyta",      ContextGroup.MICROBES,  "Haptophyta",       "Haptophyta",       151014L,    Nomenclature.Undefined),
     APUSOZOA            ("Apusozoa",        ContextGroup.MICROBES,  "Apusozoa",         "Apusozoa",         671092L,    Nomenclature.ICZN),
@@ -48,7 +48,7 @@ public enum ContextDescription {
     PLATYHELMINTHES     ("Platyhelminthes", ContextGroup.ANIMALS,   "Platyhelminthes",  "Platyhelminthes",  555379L,    Nomenclature.ICZN),
     ANNELIDS            ("Annelids",        ContextGroup.ANIMALS,   "Annelids",         "Annelida",         941620L,    Nomenclature.ICZN),
     CNIDARIA            ("Cnidarians",      ContextGroup.ANIMALS,   "Cnidarians",       "Cnidaria",         641033L,    Nomenclature.ICZN),
-    ARACHNIDES          ("Arachnides",      ContextGroup.ANIMALS,   "Arachnids",        "Arachnida",        511967L,    Nomenclature.ICZN),
+    ARACHNIDES          ("Arachnids",       ContextGroup.ANIMALS,   "Arachnids",        "Arachnida",        511967L,    Nomenclature.ICZN),
     INSECTS             ("Insects",         ContextGroup.ANIMALS,   "Insects",          "Insecta",          1062253L,   Nomenclature.ICZN),
 
     // FUNGI group

--- a/taxonomy_to_graphdb.sh
+++ b/taxonomy_to_graphdb.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Convert a smasher taxonomy file set into a neo4j graphdb suitable
 # for use with taxomachine.
 # Hmm, taxonomy path should not end with /
@@ -29,6 +31,6 @@ TV=`basename $TAXONOMY`
 JAVA="java $MEM -XX:-UseConcMarkSweepGC -jar $STANDALONE"
 
 # Build new graphdb from scratch
-$JAVA loadtaxsyn $TV $TAXONOMY/taxonomy.tsv $TAXONOMY/synonyms.tsv $GRAPHDB
+$JAVA loadtaxsyn $TV $TAXONOMY/taxonomy.tsv $TAXONOMY/synonyms.tsv $TAXONOMY/forwards.tsv $GRAPHDB
 $JAVA makecontexts $GRAPHDB
 $JAVA makegenusindexes $GRAPHDB


### PR DESCRIPTION
When loading a taxonomy into neo4j, the forwads.tsv file is now processed.

(I have yet to push a new taxomachine db to devapi; have only tested locally.)

E.g. in the below, note the difference between the `ott_id` parameter and the `ott_id` in the result.

```
curl -X "POST" -H "Content-type: application/json" -d '{"ott_id": "5507701"}' "http://localhost:7476/db/data/ext/taxonomy_v3/graphdb/taxon_info"
{
  "is_suppressed" : false,
  "tax_sources" : [ "ncbi:457703", "gbif:3089318" ],
  "unique_name" : "Adenanthellum",
  "synonyms" : [ "Adenanthemum" ],
  "name" : "Adenanthellum",
  "flags" : [ ],
  "ott_id" : 10914,
  "rank" : "genus"
}
```