### PR TITLE
incorrect reporting of tree size limit

### DIFF
--- a/src/main/java/org/opentree/taxonomy/plugins/taxonomy_v3.java
+++ b/src/main/java/org/opentree/taxonomy/plugins/taxonomy_v3.java
@@ -98,7 +98,7 @@ public class taxonomy_v3 extends ServerPlugin {
                 if (count > SUBTREE_LIMIT)
                     throw new BadInputException(
                                 String.format("The requested subtree exceeds the limit of %s taxa.",
-                                              count));
+                                              SUBTREE_LIMIT));
                 else
                     results.put("newick", tree.getRoot().getNewick(false)+";");
             }


### PR DESCRIPTION
From a [rotl issue](https://github.com/ropensci/rotl/issues/97) (reported by @rossmunce). Simple issue that the requested clade size is reported as the limit. Should probably have both in there...