### PR TITLE
bug fix when adding children to a genus hit, but the names are <= genus name length

### DIFF
--- a/src/main/java/org/opentree/tnrs/queries/SingleNamePrefixQuery.java
+++ b/src/main/java/org/opentree/tnrs/queries/SingleNamePrefixQuery.java
@@ -180,12 +180,17 @@ public class SingleNamePrefixQuery extends AbstractBaseQuery {
 	    				
 		    				String genusName = String.valueOf(genusMatch.getMatchedTaxon().getNode().getProperty(OTVocabularyPredicate.OT_OTT_TAXON_NAME.propertyName()));
 		    				char[] searchEpithet = parts[1].trim().toCharArray();
-		    				
+		    				//System.err.println("genusName = " + genusName);
 		    				// add any species to the results whose name matches the second search term prefix
 		    				for (Node sp : speciesHits) {
-		    					
+		    					String hitTaxonNameStr = String.valueOf(sp.getProperty(OTVocabularyPredicate.OT_OTT_TAXON_NAME.propertyName()));
+                                // System.err.println("hitTaxonNameStr = " + hitTaxonNameStr);
 		    					// use substring position to get just the epithet of this species match
-		    					char[] hitName = String.valueOf(sp.getProperty(OTVocabularyPredicate.OT_OTT_TAXON_NAME.propertyName())).substring(genusName.length()+1).toCharArray();
+                                if (hitTaxonNameStr.length() <= genusName.length()) {
+                                    // System.err.println("skipping short hit " + hitTaxonNameStr);
+                                    continue;
+                                }
+		    					char[] hitName = hitTaxonNameStr.substring(genusName.length()+1).toCharArray();
 
 		    					// check if the epithet matches
 		    					boolean prefixMatch = true;


### PR DESCRIPTION
Fixes server side of https://github.com/OpenTreeOfLife/feedback/issues/383
Bug arose because in OTT 3 the genus Aspidium https://tree.opentreeoflife.org/taxonomy/browse?id=6008224  is placed as a child of  https://tree.opentreeoflife.org/taxonomy/browse?id=340318

