### PR TITLE
do not query-escape names when storing them; doing so breaks matches …

### DIFF
--- a/src/main/java/org/opentree/tnrs/queries/MultiNameContextQuery.java
+++ b/src/main/java/org/opentree/tnrs/queries/MultiNameContextQuery.java
@@ -80,7 +80,10 @@ public class MultiNameContextQuery extends AbstractBaseQuery {
     public MultiNameContextQuery setSearchStrings(Map<Object, String> idNameMap) {
         clear();
         for (Object id : idNameMap.keySet()) {
-        	queriedNames.put(id, QueryParser.escape(idNameMap.get(id)).toLowerCase());
+            queriedNames.put(id,
+                           //QueryParser.escape(idNameMap.get(id)).toLowerCase()
+                           idNameMap.get(id).toLowerCase()
+                           );
         }
         return this;
     }


### PR DESCRIPTION
…to names with special characters